### PR TITLE
Fix disabled SNAC menu option when Vertical Crop is enabled

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -260,7 +260,7 @@ parameter CONF_STR2 = {
 			"P2-;",
 			"P2O9,Swap Joysticks,No,Yes;",
 			"P2OA,Multitap,Disabled,Enabled;",
-			"D6P2OQ,Serial Mode,None,SNAC;",
+			"D7P2OQ,Serial Mode,None,SNAC;",
 			"H4P2OB,SNAC Mode, 1 Player, 2 Players;",
 			"H4P2OT,SNAC Zapper,Off,On;",
 			"P2o02,Periphery,None,Zapper(Mouse),Zapper(Joy1),Zapper(Joy2),Vaus,Vaus(A-Trigger),Powerpad,Family Trainer;",


### PR DESCRIPTION
I discovered that the OSD menu logic needed to be updated because en216p, which was just recently added to status_menumask, changing the ordering.  "Serial Mode" menu option enable/disable was set to the inverse of "Vertical Crop" menu option.  When Vertical Crop is eligible for use, the "Serial Mode" menu item would be permanently greyed out.  You can break eligibility for Vertical Crop mode by setting vscale_mode=1 in mister.ini for example. (There are other ways too). After doing this, toggling the Vertical Crop option will disable it if it wasn't already. You will then notice that "Serial Mode" is now available for use.